### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/w1setown/CNN-Digit-Recognizer/security/code-scanning/1](https://github.com/w1setown/CNN-Digit-Recognizer/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only reads repository contents and does not perform any write operations, we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
